### PR TITLE
Creates Alternative Key Delimiter for Secrets Manager Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### What's new in 2.0.1 (Released 2019-02-08)
+
+* An alternative key delimiter for Secrets Manager secrets has been introduced.
+  * If a secret needs to be referenced in a CloudFormation dynamic reference, a double-underscore (__, or "dunder") may be used in lieu of colon (:).
+
 ### What's new in 2.0.0 (Released 2018-12-11)
 
 * AWS Secrets Manager support has been integrated. See `LambdaHost.CreateSecretsBuilder()`.

--- a/src/Tiger.Lambda/Tiger.Lambda.csproj
+++ b/src/Tiger.Lambda/Tiger.Lambda.csproj
@@ -4,14 +4,18 @@
     <Description>Simplifies the configuration and initialization of AWS Lambda Functions.</Description>
     <Copyright>©Cimpress 2018</Copyright>
     <AssemblyTitle>Tiger Lambda</AssemblyTitle>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <Authors>cosborn@cimpress.com</Authors>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <CodeAnalysisRuleSet>../../Tiger.ruleset</CodeAnalysisRuleSet>
     <AssemblyName>Tiger.Lambda</AssemblyName>
     <PackageId>Tiger.Lambda</PackageId>
     <PackageTags>lambda;host;aws;amazon;lambda-function</PackageTags>
-    <PackageReleaseNotes><![CDATA[➟ Release 2.0.0
+    <PackageReleaseNotes><![CDATA[➟ Release 2.0.1
+⁃ An alternative key delimiter for Secrets Manager secrets has been introduced.
+  ⁃ If a secret needs to be referenced in a CloudFormation dynamic reference, a double-underscore (__, or "dunder") may be used in lieu of colon (:).
+
+➟ Release 2.0.0
 ⁃ AWS Secrets Manager support has been integrated. See `LambdaHost.CreateSecretsBuilder()`.
 ⁃ Special support for AWS Step Functions has been upstreamed. For async exception support, investigate using the `UNWRAP_AGGREGATE_EXCEPTIONS` environment variable.
 ]]></PackageReleaseNotes>
@@ -35,20 +39,20 @@
   <Import Project="Tiger.Lambda.props" />
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.2.19" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.2.44" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.3" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.94" PrivateAssets="All" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dynamic references require the use of colon (:) as delimiter for
segments of the reference, so the colon-combined keys we have been
using to flatten secret configuration into key–value pairs absolutely
will not work. Fortunately, we have some prior art in the environment
variable configuration, which is another place where colons are
forbidden. The method of normalization for those has been applied to
the flattened keys here.

This is a backwards-compatible change. Colon continues to work, but
dunder is now _also_ accepted.

### For the Pull Request

- [x] The problem is described.
- [x] The suggested solution is summarized.
- [x] Backwards compatibility concerns are considered or dismissed.
