### PR TITLE
Adds AWS Request ID to Outermost Logging Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### What's new in 2.0.2 (Released 2019-02-15)
+
+* The AWS Request ID is added to the top level logging scope, if scopes are enabled.
+
 ### What's new in 2.0.1 (Released 2019-02-08)
 
 * An alternative key delimiter for Secrets Manager secrets has been introduced.

--- a/src/Tiger.Lambda/Tiger.Lambda.csproj
+++ b/src/Tiger.Lambda/Tiger.Lambda.csproj
@@ -4,14 +4,17 @@
     <Description>Simplifies the configuration and initialization of AWS Lambda Functions.</Description>
     <Copyright>©Cimpress 2018</Copyright>
     <AssemblyTitle>Tiger Lambda</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <Authors>cosborn@cimpress.com</Authors>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <CodeAnalysisRuleSet>../../Tiger.ruleset</CodeAnalysisRuleSet>
     <AssemblyName>Tiger.Lambda</AssemblyName>
     <PackageId>Tiger.Lambda</PackageId>
     <PackageTags>lambda;host;aws;amazon;lambda-function</PackageTags>
-    <PackageReleaseNotes><![CDATA[➟ Release 2.0.1
+    <PackageReleaseNotes><![CDATA[➟ Release 2.0.2
+⁃ The AWS Request ID is added to the top level logging scope, if scopes are enabled.
+
+➟ Release 2.0.1
 ⁃ An alternative key delimiter for Secrets Manager secrets has been introduced.
   ⁃ If a secret needs to be referenced in a CloudFormation dynamic reference, a double-underscore (__, or "dunder") may be used in lieu of colon (:).
 


### PR DESCRIPTION
This contributes to rightward drift, but there's not really anything I
can do about that until C# 8.0.
