### PR TITLE
Synthesize Cancellation Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-### What's new in 3.1.0 (Released ????-??-??)
+### What's new in 4.0.0 (Released ????-??-??)
 
+* Handlers now accept a cancellation token.
+  * The cancellation tokens are synthesized by the library; they will be canceled when approximately 500ms remain in the Function execution.
+  * This value is not yet configurable.
 * Special types have been added for handling SQS events serialized to JSON.
 
 ### What's new in 3.0.0 (Released 2020-07-07)

--- a/src/Tiger.Lambda/CancellationTokenExtensions.cs
+++ b/src/Tiger.Lambda/CancellationTokenExtensions.cs
@@ -1,0 +1,32 @@
+// <copyright file="CancellationTokenExtensions.cs" company="Cimpress, Inc.">
+//   Copyright 2020 Cimpress, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License") –
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Tiger.Lambda
+{
+    /// <summary>Extensions to the funcitonality of the <see cref="CancellationToken"/> struct.</summary>
+    static class CancellationTokenExtensions
+    {
+        public static CancellationTokenRegistration RegisterWarning(
+            this CancellationToken cancellationToken,
+            ILogger? logger) => cancellationToken.Register(
+                l => ((ILogger?)l)?.NearlyOutOfTime(),
+                logger,
+                useSynchronizationContext: false);
+    }
+}

--- a/src/Tiger.Lambda/Function.cs
+++ b/src/Tiger.Lambda/Function.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
@@ -27,6 +28,8 @@ namespace Tiger.Lambda
     /// <summary>The base class and entry point of AWS Lambda Functions.</summary>
     public abstract class Function
     {
+        internal static TimeSpan CancellationLeadTime = TimeSpan.FromMilliseconds(500);
+
         IHost? _host;
 
         /// <summary>Gets the application host.</summary>

--- a/src/Tiger.Lambda/IHandler{TIn,TOut}.cs
+++ b/src/Tiger.Lambda/IHandler{TIn,TOut}.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
@@ -32,9 +33,13 @@ namespace Tiger.Lambda
         /// </summary>
         /// <param name="input">The input to the Function.</param>
         /// <param name="context">The context of this execution of the Function.</param>
+        /// <param name="cancellationToken">A token to wach for operation cancellation.</param>
         /// <returns>
         /// A task which, when resolved, results in the output from the Function.
         /// </returns>
-        Task<TOut> HandleAsync([DisallowNull] TIn input, ILambdaContext context);
+        Task<TOut> HandleAsync(
+            [DisallowNull] TIn input,
+            ILambdaContext context,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Tiger.Lambda/IHandler{TIn}.cs
+++ b/src/Tiger.Lambda/IHandler{TIn}.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
@@ -31,9 +32,13 @@ namespace Tiger.Lambda
         /// </summary>
         /// <param name="input">The input to the Function.</param>
         /// <param name="context">The context of this execution of the Function.</param>
+        /// <param name="cancellationToken">A token to wach for operation cancellation.</param>
         /// <returns>
         /// A task which, when resolved, represents completion of the Function.
         /// </returns>
-        Task HandleAsync([DisallowNull] TIn input, ILambdaContext context);
+        Task HandleAsync(
+            [DisallowNull] TIn input,
+            ILambdaContext context,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Tiger.Lambda/LoggerExtensions.cs
+++ b/src/Tiger.Lambda/LoggerExtensions.cs
@@ -26,12 +26,22 @@ namespace Tiger.Lambda
     static class LoggerExtensions
     {
         static readonly Func<ILogger, string, IDisposable> _handlingScope = LoggerMessage.DefineScope<string>(
-            "Processing request {AwsRequestId}...");
+            Resources.Handling);
 
         static readonly Action<ILogger, Type, Exception?> _unhandledException = LoggerMessage.Define<Type>(
             Error,
             new EventId(1, nameof(UnhandledException)),
             Resources.UnhandledException);
+
+        static readonly Action<ILogger, Exception?> _canceled = LoggerMessage.Define(
+            Error,
+            new EventId(2, nameof(Canceled)),
+            Resources.Canceled);
+
+        static readonly Action<ILogger, Exception?> _nearlyOutOfTime = LoggerMessage.Define(
+            Error,
+            new EventId(3, nameof(NearlyOutOfTime)),
+            Resources.NearlyOutOfTime);
 
         /// <summary>Creates a logging scope for handling a request.</summary>
         /// <param name="logger">An application logger.</param>
@@ -48,5 +58,19 @@ namespace Tiger.Lambda
         /// <param name="exception">The exception thrown as a result of handling's failure.</param>
         public static void UnhandledException(this ILogger logger, Type type, Exception exception) =>
             _unhandledException(logger, type, exception);
+
+        /// <summary>
+        /// Writes an error log message corresponding to the event of a Function's cancellation.
+        /// </summary>
+        /// <param name="logger">An application logger.</param>
+        /// <param name="exception">An exception which was the result of timing out.</param>
+        public static void Canceled(this ILogger logger, Exception? exception = null) =>
+            _canceled(logger, exception);
+
+        /// <summary>
+        /// Writes an error log message corresponding to the event of a Function's imminent termination.
+        /// </summary>
+        /// <param name="logger">An application logger.</param>
+        public static void NearlyOutOfTime(this ILogger logger) => _nearlyOutOfTime(logger, null);
     }
 }

--- a/src/Tiger.Lambda/Properties/Resources.Designer.cs
+++ b/src/Tiger.Lambda/Properties/Resources.Designer.cs
@@ -77,5 +77,32 @@ namespace Tiger.Lambda.Properties {
                 return ResourceManager.GetString("UnhandledException", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Processing request {AwsRequestId}....
+        /// </summary>
+        public static string Handling {
+            get {
+                return ResourceManager.GetString("Handling", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Execution is nearly out of time!.
+        /// </summary>
+        public static string NearlyOutOfTime {
+            get {
+                return ResourceManager.GetString("NearlyOutOfTime", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Execution of request {AwsRequestId} has been canceled..
+        /// </summary>
+        public static string Canceled {
+            get {
+                return ResourceManager.GetString("Canceled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Tiger.Lambda/Properties/Resources.resx
+++ b/src/Tiger.Lambda/Properties/Resources.resx
@@ -125,4 +125,16 @@
     <value>Handler of {EntryType} threw an exception.</value>
     <comment>Used when an exception escapes a Lambda handler.</comment>
   </data>
+  <data name="Handling" xml:space="preserve">
+    <value>Processing request {AwsRequestId}...</value>
+    <comment>Wraps the actual handling of the event.</comment>
+  </data>
+  <data name="Canceled" xml:space="preserve">
+    <value>Execution of request has been canceled.</value>
+    <comment>Used when Function execution has been canceled due to time or any other reason.</comment>
+  </data>
+  <data name="NearlyOutOfTime" xml:space="preserve">
+    <value>Execution is nearly out of time!</value>
+    <comment>Used when Function execution is nearly out of execution time.</comment>
+  </data>
 </root>

--- a/src/Tiger.Lambda/ServiceProviderExtensions.cs
+++ b/src/Tiger.Lambda/ServiceProviderExtensions.cs
@@ -1,4 +1,4 @@
-// <copyright file="ServiceScopeExtensions.cs" company="Cimpress, Inc.">
+// <copyright file="ServiceProviderExtensions.cs" company="Cimpress, Inc.">
 //   Copyright 2020 Cimpress, Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License") –
@@ -21,14 +21,14 @@ using static Tiger.Lambda.Properties.Resources;
 
 namespace Tiger.Lambda
 {
-    /// <summary>Extensions to the functionality of the <see cref="IServiceScope"/> interface.</summary>
-    static class ServiceScopeExtensions
+    /// <summary>Extensions to the functionality of the <see cref="IServiceProvider"/> interface.</summary>
+    static class ServiceProviderExtensions
     {
-        public static IHandler<TIn> GetHandler<TIn>(this IServiceScope scope)
+        public static IHandler<TIn> GetHandler<TIn>(this IServiceProvider serviceProvider)
         {
             try
             {
-                return scope.ServiceProvider.GetRequiredService<IHandler<TIn>>();
+                return serviceProvider.GetRequiredService<IHandler<TIn>>();
             }
             catch (InvalidOperationException ioe)
             {
@@ -37,11 +37,11 @@ namespace Tiger.Lambda
             }
         }
 
-        public static IHandler<TIn, TOut> GetHandler<TIn, TOut>(this IServiceScope scope)
+        public static IHandler<TIn, TOut> GetHandler<TIn, TOut>(this IServiceProvider serviceProvider)
         {
             try
             {
-                return scope.ServiceProvider.GetRequiredService<IHandler<TIn, TOut>>();
+                return serviceProvider.GetRequiredService<IHandler<TIn, TOut>>();
             }
             catch (InvalidOperationException ioe)
             {
@@ -50,7 +50,7 @@ namespace Tiger.Lambda
             }
         }
 
-        public static ILogger? GetLogger(this IServiceScope scope, Type type) =>
-            scope.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(type);
+        public static ILogger? GetLogger(this IServiceProvider serviceProvider, Type type) =>
+            serviceProvider.GetService<ILoggerFactory>()?.CreateLogger(type);
     }
 }

--- a/src/Tiger.Lambda/SqsFunction{TIn}.cs
+++ b/src/Tiger.Lambda/SqsFunction{TIn}.cs
@@ -16,10 +16,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.SQSEvents;
@@ -39,32 +40,21 @@ namespace Tiger.Lambda
         : Function<SQSEvent>
     {
         /// <inheritdoc/>
-        public override async Task HandleAsync([DisallowNull] SQSEvent input, ILambdaContext context)
+        [DebuggerHidden]
+        internal sealed override async Task<object?> HandleCoreAsync(
+            [DisallowNull] SQSEvent input,
+            ILambdaContext context,
+            IServiceProvider serviceProvider,
+            CancellationToken cancellationToken)
         {
-            if (input is null) { throw new ArgumentNullException(nameof(input));}
-            if (context is null) { throw new ArgumentNullException(nameof(context)); }
-
-            using var scope = Host.Services.CreateScope();
-            var handler = scope.GetHandler<IEnumerable<TIn>>();
-
-            var logger = scope.GetLogger(GetType());
-            using var @finally = logger?.Handling(context);
-            try
-            {
-                var jsonOpts = scope.ServiceProvider.GetService<IOptions<JsonSerializerOptions>>();
-                var records = input
-                    .Records
-                    .Select(r => r.Body)
-                    .Select(b => JsonSerializer.Deserialize<TIn>(b, jsonOpts?.Value));
-                await handler.HandleAsync(records, context).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                // note(cosborn) Log a nice message if we can.
-                logger?.UnhandledException(GetType(), e);
-                ExceptionDispatchInfo.Throw(e);
-                throw; // note(cosborn) Unreachable.
-            }
+            var handler = serviceProvider.GetHandler<IEnumerable<TIn>>();
+            var jsonOpts = serviceProvider.GetService<IOptions<JsonSerializerOptions>>();
+            var records = input
+                .Records
+                .Select(r => r.Body)
+                .Select(b => JsonSerializer.Deserialize<TIn>(b, jsonOpts?.Value));
+            await handler.HandleAsync(records, context, cancellationToken).ConfigureAwait(false);
+            return default;
         }
     }
 }

--- a/src/Tiger.Lambda/Tiger.Lambda.csproj
+++ b/src/Tiger.Lambda/Tiger.Lambda.csproj
@@ -4,14 +4,17 @@
     <Description>Simplifies the configuration and initialization of AWS Lambda Functions.</Description>
     <Copyright>©Cimpress 2020</Copyright>
     <AssemblyTitle>Tiger Lambda</AssemblyTitle>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>cosborn@cimpress.com</Authors>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>Tiger.Lambda</AssemblyName>
     <PackageId>Tiger.Lambda</PackageId>
     <PackageTags>lambda;host;aws;amazon;lambda-function</PackageTags>
-    <PackageReleaseNotes><![CDATA[➟ Release 3.1.0
+    <PackageReleaseNotes><![CDATA[➟ Release 4.0.0
+⁃ Handlers now accept a cancellation token.
+  ⁃ The cancellation tokens are synthesized by the library; they will be canceled when appoximately 500ms remain in the Function execution.
+  ⁃ This value is not yet configurable.
 ⁃ Special types have been added for handling SQS events serialized to JSON.
 
 ➟ Release 3.0.0


### PR DESCRIPTION
These will log a message when 500 milliseconds remain in Function
execution and give handlers some time to clean up their business
before the Function is terminated.

This is meant to be like the iOS application termination model:

```swift
optional func applicationWillTerminate(_ application: UIApplication)
```

### For the Pull Request

- [x] The problem is described.
- [x] The suggested solution is summarized.
- [x] Backwards compatibility concerns are considered or dismissed.
